### PR TITLE
Separate precedence for hierarchies

### DIFF
--- a/src/test/java/org/atlasapi/application/v3/ApplicationConfigurationTranslatorTest.java
+++ b/src/test/java/org/atlasapi/application/v3/ApplicationConfigurationTranslatorTest.java
@@ -29,7 +29,8 @@ public class ApplicationConfigurationTranslatorTest {
                 .enable(Publisher.ITV)
                 .request(Publisher.NETFLIX)
                 .copyWithPrecedence(ImmutableList.of(Publisher.ITV, Publisher.BBC))
-                .copyWithWritableSources(ImmutableSet.of(Publisher.ITV));
+                .copyWithWritableSources(ImmutableSet.of(Publisher.ITV))
+                .copyWithContentHierarchyPrecedence(ImmutableList.of(Publisher.BBC, Publisher.ITV));
         
         DBObject dbo = codec.toDBObject(config);
         
@@ -42,6 +43,7 @@ public class ApplicationConfigurationTranslatorTest {
         assertTrue(decoded.canWrite(Publisher.ITV));
         assertEquals(SourceStatus.REQUESTED, decoded.statusOf(Publisher.NETFLIX));
         assertEquals(SourceStatus.AVAILABLE_DISABLED, decoded.statusOf(Publisher.PA));
+        assertEquals(config.contentHierarchyPrecedence().get(), decoded.contentHierarchyPrecedence().get());
     }
 
 }


### PR DESCRIPTION
Allow precedence ordering for merging of containers'
contents to be specified separately from the overall precedence
ordering.